### PR TITLE
Adding UML Documentation

### DIFF
--- a/doc/resources/umlDiagram.uml
+++ b/doc/resources/umlDiagram.uml
@@ -1,0 +1,3 @@
+@startuml
+
+@enduml

--- a/doc/resources/umlDiagram.uml
+++ b/doc/resources/umlDiagram.uml
@@ -1,3 +1,0 @@
-@startuml
-
-@enduml

--- a/doc/resources/umlDiagrams/abstractFactory.uml
+++ b/doc/resources/umlDiagrams/abstractFactory.uml
@@ -7,34 +7,34 @@ object Client
 interface SparseMatrixFactory
 
 ' Methods
-SparseMatrixFactory : + CreateSparseMatFromCOO(int idx_col[], int idx_row[], <precision> aij[]) : SparseMatrix
-SparseMatrixFactory : + CreateSparseMatFromCRS(int ia[], int ja[], <precision> aij[]) : SparseMatrix
-SparseMatrixFactory : + CreateSparseMatFromBCRS(int nblk, int ia[], int ja[], <precision> aij[]) : SparseMatrix
-SparseMatrixFactory : + CreateSparseMatFromELLPACK(int maxnz_row, int ja[][], <precision> aij[]) : SparseMatrix
-SparseMatrixFactory : + CreateSparseMatFromJDS(int perm[], <precision> jdiag[], int col_ind[], <precision>* jd_ptr[] ) : SparseMatrix
+SparseMatrixFactory : + createSparseMatFromCOO(int idx_col[], int idx_row[], <precision> aij[]) : SparseMatrix
+SparseMatrixFactory : + createSparseMatFromCRS(int ia[], int ja[], <precision> aij[]) : SparseMatrix
+SparseMatrixFactory : + createSparseMatFromBCRS(int nblk, int ia[], int ja[], <precision> aij[]) : SparseMatrix
+SparseMatrixFactory : + createSparseMatFromELLPACK(int maxnz_row, int ja[][], <precision> aij[]) : SparseMatrix
+SparseMatrixFactory : + createSparseMatFromJDS(int perm[], <precision> jdiag[], int col_ind[], <precision>* jd_ptr[] ) : SparseMatrix
 
 ' --------------------------- Sparse Matrix Classes ------------------------- '
 abstract class SparseMatrix
-SparseMatrix_COO : + SparseMatrix_COO()
-SparseMatrix_CRS : + SparseMatrix_CRS()
-SparseMatrix_BCRS : + SparseMatrix_BCRS()
-SparseMatrix_ELLPACK : + SparseMatrix_ELLPACK()
-SparseMatrix_JDS : + SparseMatrix_JDS()
+SparseMatrixCOO : + sparseMatrixCOO()
+SparseMatrixCRS : + sparseMatrixCRS()
+SparseMatrixBCRS : + sparseMatrixBCRS()
+SparseMatrixELLPACK : + sparseMatrixELLPACK()
+SparseMatrixJDS : + sparseMatrixJDS()
 
 ' -------------------------------- Associations ----------------------------- '
 Client ..> SparseMatrixFactory : <<use>> 
 Client ..> SparseMatrix : <<use>>
 
-SparseMatrixFactory <|.. SparseMatrix_COO
-SparseMatrixFactory <|.. SparseMatrix_CRS
-SparseMatrixFactory <|.. SparseMatrix_BCRS
-SparseMatrixFactory <|.. SparseMatrix_ELLPACK
-SparseMatrixFactory <|.. SparseMatrix_JDS
+SparseMatrixFactory <|.. SparseMatrixCOO
+SparseMatrixFactory <|.. SparseMatrixCRS
+SparseMatrixFactory <|.. SparseMatrixBCRS
+SparseMatrixFactory <|.. SparseMatrixELLPACK
+SparseMatrixFactory <|.. SparseMatrixJDS
 
-SparseMatrix_COO -|> SparseMatrix
-SparseMatrix_CRS -|> SparseMatrix
-SparseMatrix_BCRS -|> SparseMatrix
-SparseMatrix_ELLPACK -|> SparseMatrix
-SparseMatrix_JDS -|> SparseMatrix
+SparseMatrixCOO -|> SparseMatrix
+SparseMatrixCRS -|> SparseMatrix
+SparseMatrixBCRS -|> SparseMatrix
+SparseMatrixELLPACK -|> SparseMatrix
+SparseMatrixJDS -|> SparseMatrix
 
 @enduml

--- a/doc/resources/umlDiagrams/abstractFactory.uml
+++ b/doc/resources/umlDiagrams/abstractFactory.uml
@@ -1,0 +1,40 @@
+@startuml
+
+' ---------------------------------- Objects -------------------------------- '
+object Client
+
+' --------------------------- Sparse Matrix Factory ------------------------- '
+interface SparseMatrixFactory
+
+' Methods
+SparseMatrixFactory : + CreateSparseMatFromCOO(int idx_col[], int idx_row[], <precision> aij[]) : SparseMatrix
+SparseMatrixFactory : + CreateSparseMatFromCRS(int ia[], int ja[], <precision> aij[]) : SparseMatrix
+SparseMatrixFactory : + CreateSparseMatFromBCRS(int nblk, int ia[], int ja[], <precision> aij[]) : SparseMatrix
+SparseMatrixFactory : + CreateSparseMatFromELLPACK(int maxnz_row, int ja[][], <precision> aij[]) : SparseMatrix
+SparseMatrixFactory : + CreateSparseMatFromJDS(int perm[], <precision> jdiag[], int col_ind[], <precision>* jd_ptr[] ) : SparseMatrix
+
+' --------------------------- Sparse Matrix Classes ------------------------- '
+abstract class SparseMatrix
+SparseMatrix_COO : + SparseMatrix_COO()
+SparseMatrix_CRS : + SparseMatrix_CRS()
+SparseMatrix_BCRS : + SparseMatrix_BCRS()
+SparseMatrix_ELLPACK : + SparseMatrix_ELLPACK()
+SparseMatrix_JDS : + SparseMatrix_JDS()
+
+' -------------------------------- Associations ----------------------------- '
+Client ..> SparseMatrixFactory : <<use>> 
+Client ..> SparseMatrix : <<use>>
+
+SparseMatrixFactory <|.. SparseMatrix_COO
+SparseMatrixFactory <|.. SparseMatrix_CRS
+SparseMatrixFactory <|.. SparseMatrix_BCRS
+SparseMatrixFactory <|.. SparseMatrix_ELLPACK
+SparseMatrixFactory <|.. SparseMatrix_JDS
+
+SparseMatrix_COO -|> SparseMatrix
+SparseMatrix_CRS -|> SparseMatrix
+SparseMatrix_BCRS -|> SparseMatrix
+SparseMatrix_ELLPACK -|> SparseMatrix
+SparseMatrix_JDS -|> SparseMatrix
+
+@enduml

--- a/doc/resources/umlDiagrams/builderPattern.uml
+++ b/doc/resources/umlDiagrams/builderPattern.uml
@@ -1,0 +1,19 @@
+@startuml
+
+' ---------------------------------- Client --------------------------------- '
+class Client <<Director >>
+
+' ------------------------- Sparse Matrix Interface ------------------------- '
+interface SparseMatrix.setCoefficients << Builder >> 
+interface SparseMatrix.assemble << ConcreteBuilder >>
+
+' ------------------------------- Associations ------------------------------ '
+SparseMatrix.setCoefficients <. SparseMatrix.assemble : requires
+Client ..> SparseMatrix.setCoefficients : uses >
+note right of Client : repeated calls to setCoefficients()
+
+' ------------------------------ Concrete Class ----------------------------- '
+class ConcreteSparseMatrix
+SparseMatrix.assemble ..> ConcreteSparseMatrix : modifies internal storage
+
+@enduml

--- a/doc/resources/umlDiagrams/classDiagram.uml
+++ b/doc/resources/umlDiagrams/classDiagram.uml
@@ -1,0 +1,105 @@
+@startuml
+
+' ------------------------------ Abstract Class ----------------------------- '
+abstract class "SparseMatrix"
+
+' Attributes
+SparseMatrix : - nz
+SparseMatrix : - ncol
+SparseMatrix : - nrow
+SparseMatrix : ~ precision
+
+' Methods
+SparseMatrix : + SparseMatrix()
+SparseMatrix : + ~SparseMatrix()
+SparseMatrix : + setCoefficients()
+SparseMatrix : + {abstract} assemble()
+SparseMatrix : + matVec()
+SparseMatrix : + getFormat()
+
+' Sub-classes
+SparseMatrix <|-- SparseMatrix_COO
+SparseMatrix <|-- SparseMatrix_ELLPACK
+SparseMatrix <|-- SparseMatrix_CRS
+SparseMatrix <|-- SparseMatrix_BCRS
+SparseMatrix <|-- SparseMatrix_JDS
+
+' -------------------------------- COO Format ------------------------------- '
+class SparseMatrix_COO
+
+' Attributes
+SparseMatrix_COO : - aij[]
+SparseMatrix_COO : - idx_col[]
+SparseMatrix_COO : - idx_row[]
+
+' Methods
+SparseMatrix_COO : - convertToELLPACK()
+SparseMatrix_COO : - convertFromELLPACK()
+
+' Relationships
+SparseMatrix_ELLPACK *-- SparseMatrix_COO
+
+' -------------------------------- CRS Format ------------------------------- '
+class SparseMatrix_CRS
+
+' Attributes
+SparseMatrix_CRS : - aij[]
+SparseMatrix_CRS : - ia[]
+SparseMatrix_CRS : - ja[]
+
+' Methods
+SparseMatrix_CRS : - convertToELLPACK()
+SparseMatrix_CRS : - convertFromELLPACK()
+
+' Relationships
+SparseMatrix_ELLPACK *-- SparseMatrix_CRS 
+
+' ------------------------------- BCRS Format ------------------------------- '
+class SparseMatrix_BCRS
+
+' Attributes
+SparseMatrix_BCRS : - nblk
+SparseMatrix_BCRS : - aij[][][]
+SparseMatrix_BCRS : - ia[]
+SparseMatrix_BCRS : - ja[]
+
+' Methods
+SparseMatrix_BCRS : - convertFromELLPACK()
+SparseMatrix_BCRS : - convertToELLPACK()
+
+' Relationships
+SparseMatrix_ELLPACK *-- SparseMatrix_BCRS 
+
+' ------------------------------ ELLPACK Format ----------------------------- '
+class SparseMatrix_ELLPACK
+
+' Attributes
+SparseMatrix_ELLPACK : - maxnz_row
+SparseMatrix_ELLPACK : - aij[]
+SparseMatrix_ELLPACK : - ja[][]
+
+' Methods
+SparseMatrix_ELLPACK : - convertToCOO()
+SparseMatrix_ELLPACK : - convertToCRS()
+SparseMatrix_ELLPACK : - convertToBCRS()
+SparseMatrix_ELLPACK : - convertToJDS()
+
+' Relationships
+
+' -------------------------------- JDS Format ------------------------------- '
+class SparseMatrix_JDS
+
+' Attributes
+SparseMatrix_JDS : - perm[]
+SparseMatrix_JDS : - jdiag[]
+SparseMatrix_JDS : - col_ind[]
+SparseMatrix_JDS : - jd_ptr[]
+
+' Methods
+SparseMatrix_JDS : - convertFromELLPACK()
+SparseMatrix_JDS : - convertToELLPACK()
+
+'Relationships
+SparseMatrix_ELLPACK *-- SparseMatrix_JDS
+
+@enduml

--- a/doc/resources/umlDiagrams/classDiagram.uml
+++ b/doc/resources/umlDiagrams/classDiagram.uml
@@ -18,88 +18,88 @@ SparseMatrix : + matVec()
 SparseMatrix : + getFormat()
 
 ' Sub-classes
-SparseMatrix <|-- SparseMatrix_COO
-SparseMatrix <|-- SparseMatrix_ELLPACK
-SparseMatrix <|-- SparseMatrix_CRS
-SparseMatrix <|-- SparseMatrix_BCRS
-SparseMatrix <|-- SparseMatrix_JDS
+SparseMatrix <|-- SparseMatrixCOO
+SparseMatrix <|-- SparseMatrixELLPACK
+SparseMatrix <|-- SparseMatrixCRS
+SparseMatrix <|-- SparseMatrixBCRS
+SparseMatrix <|-- SparseMatrixJDS
 
 ' -------------------------------- COO Format ------------------------------- '
-class SparseMatrix_COO
+class SparseMatrixCOO
 
 ' Attributes
-SparseMatrix_COO : - aij[]
-SparseMatrix_COO : - idx_col[]
-SparseMatrix_COO : - idx_row[]
+SparseMatrixCOO : - aij[]
+SparseMatrixCOO : - idx_col[]
+SparseMatrixCOO : - idx_row[]
 
 ' Methods
-SparseMatrix_COO : - convertToELLPACK()
-SparseMatrix_COO : - convertFromELLPACK()
+SparseMatrixCOO : - convertToELLPACK()
+SparseMatrixCOO : - convertFromELLPACK()
 
 ' Relationships
-SparseMatrix_ELLPACK *-- SparseMatrix_COO
+SparseMatrixELLPACK --* SparseMatrixCOO
 
 ' -------------------------------- CRS Format ------------------------------- '
-class SparseMatrix_CRS
+class SparseMatrixCRS
 
 ' Attributes
-SparseMatrix_CRS : - aij[]
-SparseMatrix_CRS : - ia[]
-SparseMatrix_CRS : - ja[]
+SparseMatrixCRS : - aij[]
+SparseMatrixCRS : - ia[]
+SparseMatrixCRS : - ja[]
 
 ' Methods
-SparseMatrix_CRS : - convertToELLPACK()
-SparseMatrix_CRS : - convertFromELLPACK()
+SparseMatrixCRS : - convertToELLPACK()
+SparseMatrixCRS : - convertFromELLPACK()
 
 ' Relationships
-SparseMatrix_ELLPACK *-- SparseMatrix_CRS 
+SparseMatrixELLPACK --* SparseMatrixCRS 
 
 ' ------------------------------- BCRS Format ------------------------------- '
-class SparseMatrix_BCRS
+class SparseMatrixBCRS
 
 ' Attributes
-SparseMatrix_BCRS : - nblk
-SparseMatrix_BCRS : - aij[][][]
-SparseMatrix_BCRS : - ia[]
-SparseMatrix_BCRS : - ja[]
+SparseMatrixBCRS : - nblk
+SparseMatrixBCRS : - aij[][][]
+SparseMatrixBCRS : - ia[]
+SparseMatrixBCRS : - ja[]
 
 ' Methods
-SparseMatrix_BCRS : - convertFromELLPACK()
-SparseMatrix_BCRS : - convertToELLPACK()
+SparseMatrixBCRS : - convertFromELLPACK()
+SparseMatrixBCRS : - convertToELLPACK()
 
 ' Relationships
-SparseMatrix_ELLPACK *-- SparseMatrix_BCRS 
+SparseMatrixELLPACK --* SparseMatrixBCRS 
 
 ' ------------------------------ ELLPACK Format ----------------------------- '
-class SparseMatrix_ELLPACK
+class SparseMatrixELLPACK
 
 ' Attributes
-SparseMatrix_ELLPACK : - maxnz_row
-SparseMatrix_ELLPACK : - aij[]
-SparseMatrix_ELLPACK : - ja[][]
+SparseMatrixELLPACK : - maxnz_row
+SparseMatrixELLPACK : - aij[]
+SparseMatrixELLPACK : - ja[][]
 
 ' Methods
-SparseMatrix_ELLPACK : - convertToCOO()
-SparseMatrix_ELLPACK : - convertToCRS()
-SparseMatrix_ELLPACK : - convertToBCRS()
-SparseMatrix_ELLPACK : - convertToJDS()
+SparseMatrixELLPACK : - convertToCOO()
+SparseMatrixELLPACK : - convertToCRS()
+SparseMatrixELLPACK : - convertToBCRS()
+SparseMatrixELLPACK : - convertToJDS()
 
 ' Relationships
 
 ' -------------------------------- JDS Format ------------------------------- '
-class SparseMatrix_JDS
+class SparseMatrixJDS
 
 ' Attributes
-SparseMatrix_JDS : - perm[]
-SparseMatrix_JDS : - jdiag[]
-SparseMatrix_JDS : - col_ind[]
-SparseMatrix_JDS : - jd_ptr[]
+SparseMatrixJDS : - perm[]
+SparseMatrixJDS : - jdiag[]
+SparseMatrixJDS : - col_ind[]
+SparseMatrixJDS : - jd_ptr[]
 
 ' Methods
-SparseMatrix_JDS : - convertFromELLPACK()
-SparseMatrix_JDS : - convertToELLPACK()
+SparseMatrixJDS : - convertFromELLPACK()
+SparseMatrixJDS : - convertToELLPACK()
 
 'Relationships
-SparseMatrix_ELLPACK *-- SparseMatrix_JDS
+SparseMatrixELLPACK --* SparseMatrixJDS
 
 @enduml

--- a/doc/resources/umlDiagrams/stateDiagram.uml
+++ b/doc/resources/umlDiagrams/stateDiagram.uml
@@ -1,0 +1,17 @@
+@startuml
+
+' ---------------------------- Constructor Begin ---------------------------- '
+[*] --> Initialized : SparseMatrix Constructor
+Initialized -> Building : setCoefficients() 
+
+' ------------------------------ Building State ----------------------------- '
+Building -> Building : setCoefficients()
+Building --> Assembled : assemble()
+
+' ----------------------------- Assembling State ---------------------------- '
+Assembled --> Building : setCoefficients()
+Assembled --> [*] : getFormat ()
+
+' ----------------------------- Constructor End ----------------------------- '
+
+@enduml

--- a/doc/sphinx/source/developerDocs/umlDiagram.rst
+++ b/doc/sphinx/source/developerDocs/umlDiagram.rst
@@ -3,29 +3,57 @@
 UML Diagram
 ===========
 
+The structure of the SpMV library is documented using the Unified Modeling Language (UML).
+Several UML diagrams are included below showcasing the classes, the abstract factory, the builder pattern, and an example state diagram.
+
 Class Diagram
 -------------
+
+The class diagram showing the class hierarchy as well as attributes and methods for each level class is shown in the figure below.
 
 .. uml:: ../../../resources/umlDiagrams/classDiagram.uml
     :caption: Class hierarchy UML diagram.
     :align: center
 
+For SpMV, the abstract class is ``SparseMatrix``, which contains extensions to the associated concrete classes for each sparse matrix format.
+The sparse matrix format that will be used for computation is ELLPACK, so each concrete object is a composition of itself with an instance of the ``SparseMatrixELLPACK`` concrete class.
+This centralized class is useful for minimizing code duplication and redundancy.
+The abstract class contains several common attributes and methods that are inherited by the concrete classes, while each concrete class houses its own individual attributes and methods.
+
 Abstract Factory
 ----------------
+
+The Abstract Factory structure used in SpMV provides an interface for creating families of related or dependent objects without their concrete classes.
+The Abstract Factory design for SpMV is shown in the figure below.
 
 .. uml:: ../../../resources/umlDiagrams/abstractFactory.uml
     :caption: Abstract factory UML diagram.
     :align: center
 
+In the abstract factory, a client initializes a sparse matrix object using the ``SparseMatrixFactory`` interface.
+This interface will call one of several concrete classes to generate a sparse matrix in the desired form.
+The interface provides the client link to a sparse matrix object that the client can use without direct interaction with many of the methods within the dependent classes.
+
 Builder Pattern
 ---------------
+
+Initializing and setting up a sparse matrix within SpMV requires several steps to properly define all of the required parameters.
+A builder pattern for a client generating a sparse matrix is shown below.
 
 .. uml:: ../../../resources/umlDiagrams/builderPattern.uml
     :caption: Builder pattern UML diagram.
     :align: center
 
+In this builder pattern, once a client has initialized a sparse matrix it can call this matrix to set the coefficients within it.
+This is done with repeated calls to the ``setCoefficients`` method.
+Once the spares matrix is set, it can be assembled and stored in the desired format.
+This assembly results in a fully initialized ``ConcreteSparseMatrix`` object instance that can be used for computation.
+
 State Diagram
 ---------------
+
+Below is an example of the state diagram for building a matrix within SpMV, setting the coefficients, assembling it, and then obtaining the format.
+This diagram is only an example and can and should be expanded for other use cases.
 
 .. uml:: ../../../resources/umlDiagrams/stateDiagram.uml
     :caption: State Diagram UML diagram.

--- a/doc/sphinx/source/developerDocs/umlDiagram.rst
+++ b/doc/sphinx/source/developerDocs/umlDiagram.rst
@@ -34,6 +34,10 @@ In the abstract factory, a client initializes a sparse matrix object using the `
 This interface will call one of several concrete classes to generate a sparse matrix in the desired form.
 The interface provides the client link to a sparse matrix object that the client can use without direct interaction with many of the methods within the dependent classes.
 
+The COO implementation is in the ``coo.hpp`` file and the CRS is in ``crs.hpp`` file currently located in the ``src`` directory.
+.. TODO add in where the BCRS, ELLPACK, and JDS implementations are.
+They are basic functions written in C that create the sparse matrix formats.
+
 Builder Pattern
 ---------------
 

--- a/doc/sphinx/source/developerDocs/umlDiagram.rst
+++ b/doc/sphinx/source/developerDocs/umlDiagram.rst
@@ -34,10 +34,6 @@ In the abstract factory, a client initializes a sparse matrix object using the `
 This interface will call one of several concrete classes to generate a sparse matrix in the desired form.
 The interface provides the client link to a sparse matrix object that the client can use without direct interaction with many of the methods within the dependent classes.
 
-The COO implementation is in the ``coo.hpp`` file and the CRS is in ``crs.hpp`` file currently located in the ``src`` directory.
-.. TODO add in where the BCRS, ELLPACK, and JDS implementations are.
-They are basic functions written in C that create the sparse matrix formats.
-
 Builder Pattern
 ---------------
 

--- a/doc/sphinx/source/developerDocs/umlDiagram.rst
+++ b/doc/sphinx/source/developerDocs/umlDiagram.rst
@@ -3,4 +3,30 @@
 UML Diagram
 ===========
 
-.. uml:: ../../../resources/umlDiagram.uml
+Class Diagram
+-------------
+
+.. uml:: ../../../resources/umlDiagrams/classDiagram.uml
+    :caption: Class hierarchy UML diagram.
+    :align: center
+
+Abstract Factory
+----------------
+
+.. uml:: ../../../resources/umlDiagrams/abstractFactory.uml
+    :caption: Abstract factory UML diagram.
+    :align: center
+
+Builder Pattern
+---------------
+
+.. uml:: ../../../resources/umlDiagrams/builderPattern.uml
+    :caption: Builder pattern UML diagram.
+    :align: center
+
+State Diagram
+---------------
+
+.. uml:: ../../../resources/umlDiagrams/stateDiagram.uml
+    :caption: State Diagram UML diagram.
+    :align: center

--- a/doc/sphinx/source/developerDocs/umlDiagram.rst
+++ b/doc/sphinx/source/developerDocs/umlDiagram.rst
@@ -1,0 +1,6 @@
+.. _umlDiagram:
+
+UML Diagram
+===========
+
+.. uml:: ../../../resources/umlDiagram.uml


### PR DESCRIPTION
Addresses issue #26.

This PR adds the following UML diagrams: class diagram, abstract factory, builder pattern, and state diagram. These are included in `doc/resources/umlDiagrams/` and are automatically generated into the Sphinx documentation using PlantUML and the associated Sphinx-contrib plugin. This also includes descriptions for each type of diagram.

This PR adds two dependencies for documentation:
1. The Python package `sphinxcontrib-plantuml` 
2. PlantUML

This PR is blocked by PR #47, which sets up the centralized Sphinx documentation. Many of the diffs included in this PR are artificial as they will be cleared up by the blocking PR.

Note: This PR is co-authored by Bernardo Pacini and Jenna King