### PR TITLE
Adding Design Patterns Documentation

### DIFF
--- a/doc/resources/designPatterns/behavioral.uml
+++ b/doc/resources/designPatterns/behavioral.uml
@@ -1,0 +1,22 @@
+@startuml
+
+' ---------------------------------- Objects -------------------------------- '
+card SparseMatrixELLPACK
+
+card SparseMatrixJDS
+
+card SparseMatrixBCRS
+
+card SparseMatrixCOO
+
+card SparseMatrixCRS
+
+SparseMatrixELLPACK <--> SparseMatrixJDS
+
+SparseMatrixELLPACK <--> SparseMatrixBCRS
+
+SparseMatrixELLPACK <--> SparseMatrixCOO
+
+SparseMatrixELLPACK <--> SparseMatrixCRS
+
+@enduml

--- a/doc/resources/designPatterns/behavioral.uml
+++ b/doc/resources/designPatterns/behavioral.uml
@@ -1,6 +1,6 @@
 @startuml
 
-' ---------------------------------- Objects -------------------------------- '
+' ------------------------ Behavioral Design Pattern ------------------------ '
 card SparseMatrixELLPACK
 
 card SparseMatrixJDS

--- a/doc/resources/designPatterns/creational.uml
+++ b/doc/resources/designPatterns/creational.uml
@@ -1,0 +1,73 @@
+@startuml
+
+' ------------------------- Creational Design Pattern ----------------------- '
+
+' -------------------------- Abstract Sparse Matrix ------------------------- '
+abstract class SparseMatrix
+
+' Attributes
+SparseMatrix : ~ dataType: Boolean precision
+
+' Sub-classes
+SparseMatrix <-- SparseMatrixCOO
+SparseMatrix <-- SparseMatrixELLPACK
+SparseMatrix <-- SparseMatrixCRS
+SparseMatrix <-- SparseMatrixBCRS
+SparseMatrix <-- SparseMatrixJDS
+
+' -------------------------------- COO Format ------------------------------- '
+class SparseMatrixCOO
+
+' Methods
+SparseMatrixCOO : + create()
+SparseMatrixCOO : + set()
+SparseMatrixCOO : + get()
+SparseMatrixCOO : + transform()
+SparseMatrixCOO : + destroy()
+
+' -------------------------------- CRS Format ------------------------------- '
+class SparseMatrixCRS
+
+' Methods
+SparseMatrixCRS : + create()
+SparseMatrixCRS : + set()
+SparseMatrixCRS : + get()
+SparseMatrixCRS : + transform()
+SparseMatrixCRS : + destroy()
+
+' -------------------------------- BCRS Format ------------------------------- '
+class SparseMatrixBCRS
+
+' Methods
+SparseMatrixBCRS : + create()
+SparseMatrixBCRS : + set()
+SparseMatrixBCRS : + get()
+SparseMatrixBCRS : + transform()
+SparseMatrixBCRS : + destroy()
+
+' -------------------------------- JDS Format ------------------------------- '
+class SparseMatrixJDS
+
+' Methods
+SparseMatrixJDS : + create()
+SparseMatrixJDS : + set()
+SparseMatrixJDS : + get()
+SparseMatrixJDS : + transform()
+SparseMatrixJDS : + destroy()
+
+' -------------------------------- ELLPACK Format ------------------------------- '
+class SparseMatrixELLPACK
+
+' Methods
+SparseMatrixELLPACK : + create()
+SparseMatrixELLPACK : + set()
+SparseMatrixELLPACK : + get()
+SparseMatrixELLPACK : + transform()
+SparseMatrixELLPACK : + destroy()
+SparseMatrixELLPACK : + solve()
+
+
+
+
+
+@enduml

--- a/doc/resources/designPatterns/structural.uml
+++ b/doc/resources/designPatterns/structural.uml
@@ -1,0 +1,37 @@
+@startuml
+
+' ------------------------ Structural Design Pattern ------------------------ '
+:userInputs:
+
+' ------------------------------- User Inputs ------------------------------- '
+card Matrix
+card MatrixDataType
+card MatrixType
+
+' ------------------------------- Input Check ------------------------------- '
+card check
+Matrix --> check
+MatrixDataType --> check
+MatrixType --> check
+
+' ------------------------------ Process Setup ------------------------------ '
+card processSetup
+check --> processSetup
+
+' ---------------------------- Change to ELLPACK ---------------------------- '
+card transformToELLPACK
+processSetup --> transformToELLPACK
+
+' ------------------------------- Solve Matrix ------------------------------ '
+card solve
+transformToELLPACK --> solve
+
+' ----------------------------- Change to Output ---------------------------- '
+card ELLPACKtoMatrixType
+solve --> ELLPACKtoMatrixType
+
+' ---------------------------------- Output --------------------------------- '
+card output
+ELLPACKtoMatrixType --> output
+
+@enduml

--- a/doc/resources/designPatterns/structural.uml
+++ b/doc/resources/designPatterns/structural.uml
@@ -5,14 +5,14 @@
 
 ' ------------------------------- User Inputs ------------------------------- '
 card Matrix
-card MatrixDataType
-card MatrixType
+card Precision
+card MatrixOutputType
 
 ' ------------------------------- Input Check ------------------------------- '
 card check
 Matrix --> check
-MatrixDataType --> check
-MatrixType --> check
+Precision --> check
+MatrixOutputType --> check
 
 ' ------------------------------ Process Setup ------------------------------ '
 card processSetup

--- a/doc/sphinx/source/developerDocs/designPatterns.rst
+++ b/doc/sphinx/source/developerDocs/designPatterns.rst
@@ -1,0 +1,8 @@
+.. _designPatterns:
+
+Design Patterns
+===============
+
+.. uml:: ../../../resources/designPatterns/behavioral.uml
+    :caption: Behavioral Design Pattern.
+    :align: center

--- a/doc/sphinx/source/developerDocs/designPatterns.rst
+++ b/doc/sphinx/source/developerDocs/designPatterns.rst
@@ -7,24 +7,41 @@ Design Patterns
 Behavioral Design Pattern - Mediator
 ------------------------------------
 
+The behavioral design pattern is shown in the figure below.
 
 .. uml:: ../../../resources/designPatterns/behavioral.uml
     :caption: Behavioral Design Pattern - Mediator.
     :align: center
 
-
+The pattern here centralizes all sparse matrix types around the ELLPACK type. 
+The user input will be automatically converted to the ELLPACK type for all calculations.
+After the matrix vector multiplication is performed on the ELLPACK type, the matrix will be converted back into the desired output type.
+This Mediator pattern was chosen as ELLPACK acts as a mediator for all other sparse matrix types.
+Each sparse matrix type depends solely on the single mediator ELLPACK class rather than being fully coupled. 
 
 Creational Design Pattern
 -------------------------
+
+The creational design pattern is shown in the image below.
 
 .. uml:: ../../../resources/designPatterns/creational.uml
     :caption: Creational Design Pattern.
     :align: center
 
+.. note::
+
+    This creational pattern closely mirrors the UML class diagram.
+
 Structural Design Pattern
 -------------------------
+
+The structural design pattern is shown in the image below.
 
 .. uml:: ../../../resources/designPatterns/structural.uml
     :caption: Structural Design Pattern - Facade.
     :align: center
 
+This pattern demonstrates the interactions between the client and the facade class that provides the interface for the user.
+The facade pattern was chosen as it is the most fitting for the SpMV library.
+The user has access to the three inputs: matrix, matrix data type, and sparse matrix type.
+At this point, the user no longer needs access to the methods and attributes of the SpMV class as the process is handled by the library.

--- a/doc/sphinx/source/developerDocs/designPatterns.rst
+++ b/doc/sphinx/source/developerDocs/designPatterns.rst
@@ -3,6 +3,28 @@
 Design Patterns
 ===============
 
+
+Behavioral Design Pattern - Mediator
+------------------------------------
+
+
 .. uml:: ../../../resources/designPatterns/behavioral.uml
-    :caption: Behavioral Design Pattern.
+    :caption: Behavioral Design Pattern - Mediator.
     :align: center
+
+
+
+Creational Design Pattern
+-------------------------
+
+.. uml:: ../../../resources/designPatterns/creational.uml
+    :caption: Creational Design Pattern.
+    :align: center
+
+Structural Design Pattern
+-------------------------
+
+.. uml:: ../../../resources/designPatterns/structural.uml
+    :caption: Structural Design Pattern - Facade.
+    :align: center
+


### PR DESCRIPTION
Addresses issue #29.

This PR adds the following Design Patterns: creational, structural, and behavioral. These are included in `/doc/resources/designPatterns/` and are automatically generated into the Sphinx documentation using PlantUML and the associated Sphinx-contrib plugin. Descriptions for each type of diagram are also included in the documentation.

This PR is blocked by PRs #47 and #52, which set up the Sphinx documentation and PlantUML configuration.

Note: This PR is co-authored by Jenna King and Bernardo Pacini