### PR TITLE
Added tests matrix vector tests for each sparse matrix format

### DIFF
--- a/doc/testing.md
+++ b/doc/testing.md
@@ -6,6 +6,10 @@ Tests for these will include
 * matrix of zeros and make sure returned vector is zero
 * tridiagonal banded matrix
 * a random matrix and random vector checked against a simple dense matrix vector multiplication (setting the random seed at the beginning of the test to ensure reproducibility)
+* Each test is run for each matrix type
+* Matrices will be created for each test using SparseMatrix Factory
+* Entries are set by building a map and using the setCoefficients method
+* All Tests are templated to allow for single/double precision
 
 ## Single/double precision
 * Define a testing class that is templated to define whether or not to use single or double precision data types

--- a/test/testSparseMaVec_BCRS.cpp
+++ b/test/testSparseMaVec_BCRS.cpp
@@ -1,0 +1,171 @@
+//TESTS FOR COO format sparse matrix runs 5 tests:
+//1) MatVec with identity matrix
+//2) MatVec with diagonal matrix
+//3) MatVec with zeros Matrix
+//4) Matvec with tridiagonal matrix
+//5) Matvec with random full desnse matrix
+#include "SparseMatrix.hpp" //import sparse matrix library
+#include "unit_test_framework.h" //for using testing framework
+#include "stdlib.h"//for random
+
+//Test for identity matvec
+TEST(MatVec_BCRS_Identity){
+    //num rows and cols for matrix
+    size_t rows = 10;
+    size_t cols = 10;
+    SparseMatrix<FP_TYPE> * mat = Matrix_Factory("BCRS",rows,cols);
+    FP_TYPE x[10] = {1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0,9.0,10.0};
+    FP_TYPE b[10];
+    std::map<std::pair<size_t,size_t>, FP_TYPE > value_Map;
+    for(size_t i = 0; i < rows; i++){
+
+        std::pair<size_t,size_t>  key;
+        key = std::make_pair(i,i);
+
+        std::pair<std::pair<size_t,size_t>, FP_TYPE> map_pair;
+        map_pair = std::make_pair(key,1.0);
+        value_Map.insert(map_pair);
+    }
+    
+    //set coefficients of sparse matrix to be the values in the map
+    mat->setCoefficients(value_Map);
+    mat->matvec(x,b);
+    //loop over values of b and check they are the same as x x was multiplied by the identity matrix
+    for (size_t i = 0;i < cols; i++){
+        ASSERT_ALMOST_EQUAL(x[i],b[i],1e-6);
+    }
+    delete mat;
+}  
+
+//Test For Diagonal matvec 
+TEST(MatVec_BCRS_Diag){
+    //num rows and cols for matrix
+    size_t rows = 10;
+    size_t cols = 10;
+    SparseMatrix<FP_TYPE> * mat = Matrix_Factory("BCRS",rows,cols);
+    FP_TYPE x[10] = {1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0};
+    FP_TYPE b[10];
+    FP_TYPE b_sol[10] = {1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0,9.0,10.0};
+    std::map<std::pair<size_t,size_t>, FP_TYPE > value_Map;
+    FP_TYPE val  = 1.0;
+    for(size_t i = 0; i < rows; i++){
+        std::pair<size_t,size_t>  key;
+        key = std::make_pair(i,i);
+
+        std::pair<std::pair<size_t,size_t>, FP_TYPE> map_pair;
+        map_pair= std::make_pair(key,val);
+        value_Map.insert(map_pair);
+        val = val + 1; 
+        
+    }
+    //set coefficients of sparse matrix to be the values in the map
+    mat->setCoefficients(value_Map);
+    mat->matVec(x,b);
+    //loop over values of b and check they are the same as b_sol
+    for (size_t i = 0;i < cols; i++){
+        ASSERT_ALMOST_EQUAL(b_sol[i],b[i],1e-6);
+    }
+    delete mat;
+}   
+//Test for zero matrix matvec
+TEST(MatVec_BCRS_Zero){
+    //num rows and cols for matrix
+    size_t rows = 10;
+    size_t cols = 10;
+    SparseMatrix<FP_TYPE> * mat = Matrix_Factory("BCRS",rows,cols);
+    FP_TYPE x[10] = {1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0,9.0,10.0};
+    FP_TYPE b[10];
+    mat->matvec(x,b);
+    //loop over values of b and check they are the same as x x was multiplied by the identity matrix
+    for (size_t i = 0;i < cols; i++){
+        ASSERT_ALMOST_EQUAL(0,b[i],1e-6);
+    }
+    delete mat;
+}
+//Tests for banded matvec
+TEST(MatVec_BCRS_BANDED){
+    //num rows and cols for matrix
+    size_t rows = 10;
+    size_t cols = 10;
+    SparseMatrix<FP_TYPE> * mat = Matrix_Factory("BCRS",rows,cols);
+    FP_TYPE x[10] = {1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0};
+    FP_TYPE b[10];
+    FP_TYPE b_sol[10] = {1.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0};
+    std::map<std::pair<size_t,size_t>, FP_TYPE > value_Map;
+    for(size_t i = 0; i < rows; i++){
+        std::pair<size_t,size_t>  key;
+        key = std::make_pair(i,i);
+        std::pair<std::pair<size_t,size_t>, FP_TYPE> map_pair;
+        map_pair= std::make_pair(key,2);
+        value_Map.insert(map_pair);
+
+        if (i > 0){
+            std::pair<size_t,size_t>  key;
+            key = std::make_pair(i,i-1);
+            std::pair<std::pair<size_t,size_t>, FP_TYPE> map_pair;
+            map_pair= std::make_pair(key,-1);
+            value_Map.insert(map_pair);
+        }
+        
+        if (i < rows-1){
+            std::pair<size_t,size_t>  key;
+            key = std::make_pair(i,i+1);
+            std::pair<std::pair<size_t,size_t>, FP_TYPE> map_pair;
+            map_pair= std::make_pair(key,-1);
+            value_Map.insert(map_pair);
+        }
+    }
+    
+    //set coefficients of sparse matrix to be the values in the map
+    mat->setCoefficients(value_Map);
+    mat->matVec(x,b);
+    //loop over values of b and check they are the same as b_sol
+    for (size_t i = 0;i < cols; i++){
+        ASSERT_ALMOST_EQUAL(b_sol[i],b[i],1e-6);
+    }
+    delete mat;
+}
+//test for random dense matvec
+TEST(MatVec_BCRS_Dense){
+    size_t rows = 10;
+    size_t cols = 10;
+    SparseMatrix<FP_TYPE> * mat = Matrix_Factory("BCRS",rows,cols);
+    FP_TYPE mat_dense[10][10];
+    FP_TYPE x[10] = {1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0,9.0,10.0};
+    FP_TYPE b[10];
+    FP_TYPE b_sol[10] = {0,0,0,0,0,0,0,0,0,0};
+    std::map<std::pair<size_t,size_t>, FP_TYPE > value_Map;
+    //set random seed so test dont change run to run
+    srand(100);
+    for(size_t i = 0; i < rows; i++){
+        for (size_t j = 0; j<cols; j++){
+            FP_TYPE val = rand();
+            mat_dense[i][j] = val;
+            std::pair<size_t,size_t>  key;
+            key = std::make_pair(i,i);
+            std::pair<std::pair<size_t,size_t>, FP_TYPE> map_pair;
+            map_pair = std::make_pair(key,val);
+            value_Map.insert(map_pair);
+        }
+
+    }
+
+    // dense matrix vector multiplication (known implemenation)
+    for (size_t i  = 0; i <rows; i++){
+        for (size_t j = 0; j<cols; j++){
+            b_sol[i] = b_sol[i] + mat_dense[i][j]*x[j];
+        }
+    }
+    
+    //set coefficients of sparse matrix to be the values in the map
+    mat->setCoefficients(value_Map);
+    mat->matvec(x,b);
+    //loop over values of b and check they are the same as x x was multiplied by the identity matrix
+    for (size_t i = 0;i < cols; i++){
+        ASSERT_ALMOST_EQUAL(b_sol[i],b[i],1e-6);
+    }
+
+    delete mat;
+}
+
+TEST MAIN()

--- a/test/testSparseMatVec_COO.cpp
+++ b/test/testSparseMatVec_COO.cpp
@@ -1,0 +1,171 @@
+//TESTS FOR COO format sparse matrix runs 5 tests:
+//1) MatVec with identity matrix
+//2) MatVec with diagonal matrix
+//3) MatVec with zeros Matrix
+//4) Matvec with tridiagonal matrix
+//5) Matvec with random full desnse matrix
+
+#include "SparseMatrix.hpp" //import sparse matrix library
+#include "unit_test_framework.h" //for using testing framework
+#include "stdlib.h"//for random
+
+//Test for identity matvec
+TEST(MatVec_COO_Identity){
+    //num rows and cols for matrix
+    size_t rows = 10;
+    size_t cols = 10;
+    SparseMatrix<FP_TYPE> * mat = Matrix_Factory("COO",rows,cols);
+    FP_TYPE x[10] = {1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0,9.0,10.0};
+    FP_TYPE b[10];
+    std::map<std::pair<size_t,size_t>, FP_TYPE > value_Map;
+    for(size_t i = 0; i < rows; i++){
+
+        std::pair<size_t,size_t>  key;
+        key = std::make_pair(i,i);
+
+        std::pair<std::pair<size_t,size_t>, FP_TYPE> map_pair;
+        map_pair = std::make_pair(key,1.0);
+        value_Map.insert(map_pair);
+    }
+    
+    //set coefficients of sparse matrix to be the values in the map
+    mat->setCoefficients(value_Map);
+    mat->matvec(x,b);
+    //loop over values of b and check they are the same as x x was multiplied by the identity matrix
+    for (size_t i = 0;i < cols; i++){
+        ASSERT_ALMOST_EQUAL(x[i],b[i],1e-6);
+    }
+    delete mat;
+}   
+//Test For Diagonal matvec 
+TEST(MatVec_COO_Diag){
+    //num rows and cols for matrix
+    size_t rows = 10;
+    size_t cols = 10;
+    SparseMatrix<FP_TYPE> * mat = Matrix_Factory("COO",rows,cols);
+    FP_TYPE x[10] = {1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0};
+    FP_TYPE b[10];
+    FP_TYPE b_sol[10] = {1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0,9.0,10.0};
+    std::map<std::pair<size_t,size_t>, FP_TYPE > value_Map;
+    FP_TYPE val  = 1.0;
+    for(size_t i = 0; i < rows; i++){
+        std::pair<size_t,size_t>  key;
+        key = std::make_pair(i,i);
+
+        std::pair<std::pair<size_t,size_t>, FP_TYPE> map_pair;
+        map_pair= std::make_pair(key,val);
+        value_Map.insert(map_pair);
+        val = val + 1; 
+    }
+    
+    //set coefficients of sparse matrix to be the values in the map
+    mat->setCoefficients(value_Map);
+    mat->matVec(x,b);
+    //loop over values of b and check they are the same as b_sol
+    for (size_t i = 0;i < cols; i++){
+        ASSERT_ALMOST_EQUAL(b_sol[i],b[i],1e-6);
+    }
+    delete mat;
+}   
+//Test for zero matrix matvec
+TEST(MatVec_COO_Zero){
+    //num rows and cols for matrix
+    size_t rows = 10;
+    size_t cols = 10;
+    SparseMatrix<FP_TYPE> * mat = Matrix_Factory("COO",rows,cols);
+    FP_TYPE x[10] = {1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0,9.0,10.0};
+    FP_TYPE b[10];
+    mat->matvec(x,b);
+    //loop over values of b and check they are the same as x x was multiplied by the identity matrix
+    for (size_t i = 0;i < cols; i++){
+        ASSERT_ALMOST_EQUAL(0,b[i],1e-6);
+    }
+    delete mat;
+}   
+//Tests for banded matvec
+TEST(matVec_COO_BANDED){
+    //num rows and cols for matrix
+    size_t rows = 10;
+    size_t cols = 10;
+    SparseMatrix<FP_TYPE> * mat = Matrix_Factory("COO",rows,cols);
+    FP_TYPE x[10] = {1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0};
+    FP_TYPE b[10];
+    FP_TYPE b_sol[10] = {1.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0};
+    std::map<std::pair<size_t,size_t>, FP_TYPE > value_Map;
+    for(size_t i = 0; i < rows; i++){
+        std::pair<size_t,size_t>  key;
+        key = std::make_pair(i,i);
+        std::pair<std::pair<size_t,size_t>, FP_TYPE> map_pair;
+        map_pair= std::make_pair(key,2);
+        value_Map.insert(map_pair);
+
+        if (i > 0){
+            std::pair<size_t,size_t>  key;
+            key = std::make_pair(i,i-1);
+            std::pair<std::pair<size_t,size_t>, FP_TYPE> map_pair;
+            map_pair= std::make_pair(key,-1);
+            value_Map.insert(map_pair);
+        }
+        
+        if (i < rows-1){
+            std::pair<size_t,size_t>  key;
+            key = std::make_pair(i,i+1);
+            std::pair<std::pair<size_t,size_t>, FP_TYPE> map_pair;
+            map_pair= std::make_pair(key,-1);
+            value_Map.insert(map_pair);
+        }
+    }
+    
+    //set coefficients of sparse matrix to be the values in the map
+    mat->setCoefficients(value_Map);
+    mat->matVec(x,b);
+    //loop over values of b and check they are the same as b_sol
+    for (size_t i = 0;i < cols; i++){
+        ASSERT_ALMOST_EQUAL(b_sol[i],b[i],1e-6);
+    }
+    delete mat;
+}
+//test for random dense matvec
+TEST(MatVec_COO_Dense){
+    size_t rows = 10;
+    size_t cols = 10;
+    SparseMatrix<FP_TYPE> * mat = Matrix_Factory("COO",rows,cols);
+    FP_TYPE mat_dense[10][10];
+    FP_TYPE x[10] = {1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0,9.0,10.0};
+    FP_TYPE b[10];
+    FP_TYPE b_sol[10] = {0,0,0,0,0,0,0,0,0,0};
+    std::map<std::pair<size_t,size_t>, FP_TYPE > value_Map;
+    //set random seed so test dont change run to run
+    srand(100);
+    for(size_t i = 0; i < rows; i++){
+        for (size_t j = 0; j<cols; j++){
+            FP_TYPE val = rand();
+            mat_dense[i][j] = val;
+            std::pair<size_t,size_t>  key;
+            key = std::make_pair(i,i);
+            std::pair<std::pair<size_t,size_t>, FP_TYPE> map_pair;
+            map_pair = std::make_pair(key,val);
+            value_Map.insert(map_pair);
+        }
+
+    }
+
+    // dense matrix vector multiplication (known implemenation)
+    for (size_t i  = 0; i <rows; i++){
+        for (size_t j = 0; j<cols; j++){
+            b_sol[i] = b_sol[i] + mat_dense[i][j]*x[j];
+        }
+    }
+    
+    //set coefficients of sparse matrix to be the values in the map
+    mat->setCoefficients(value_Map);
+    mat->matvec(x,b);
+    //loop over values of b and check they are the same as x x was multiplied by the identity matrix
+    for (size_t i = 0;i < cols; i++){
+        ASSERT_ALMOST_EQUAL(b_sol[i],b[i],1e-6);
+    }
+
+    delete mat;
+}
+
+TEST MAIN()

--- a/test/testSparseMatVec_CRS.cpp
+++ b/test/testSparseMatVec_CRS.cpp
@@ -1,0 +1,171 @@
+//TESTS FOR CRS format sparse matrix runs 5 tests:
+//1) MatVec with identity matrix
+//2) MatVec with diagonal matrix
+//3) MatVec with zeros Matrix
+//4) Matvec with tridiagonal matrix
+//5) Matvec with random full desnse matrix
+#include "SparseMatrix.hpp" //import sparse matrix library
+#include "unit_test_framework.h" //for using testing framework
+#include "stdlib.h"//for random
+
+//Test for identity matvec
+TEST(MatVec_CRS_Identity){
+    //num rows and cols for matrix
+    size_t rows = 10;
+    size_t cols = 10;
+    SparseMatrix<FP_TYPE> * mat = Matrix_Factory("CRS",rows,cols);
+    FP_TYPE x[10] = {1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0,9.0,10.0};
+    FP_TYPE b[10];
+    std::map<std::pair<size_t,size_t>, FP_TYPE > value_Map;
+    for(size_t i = 0; i < rows; i++){
+
+        std::pair<size_t,size_t>  key;
+        key = std::make_pair(i,i);
+
+        std::pair<std::pair<size_t,size_t>, FP_TYPE> map_pair;
+        map_pair = std::make_pair(key,1.0);
+        value_Map.insert(map_pair);
+    }
+    
+    //set coefficients of sparse matrix to be the values in the map
+    mat->setCoefficients(value_Map);
+    mat->matvec(x,b);
+    //loop over values of b and check they are the same as x x was multiplied by the identity matrix
+    for (size_t i = 0;i < cols; i++){
+        ASSERT_ALMOST_EQUAL(x[i],b[i],1e-6);
+    }
+    delete mat;
+}   
+//Test For Diagonal matvec
+TEST(MatVec_CRS_Diag){
+    //num rows and cols for matrix
+    size_t rows = 10;
+    size_t cols = 10;
+    SparseMatrix<FP_TYPE> * mat = Matrix_Factory("CRS",rows,cols);
+    FP_TYPE x[10] = {1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0};
+    FP_TYPE b[10];
+    FP_TYPE b_sol[10] = {1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0,9.0,10.0};
+    std::map<std::pair<size_t,size_t>, FP_TYPE > value_Map;
+    FP_TYPE val  = 1.0;
+    for(size_t i = 0; i < rows; i++){
+        std::pair<size_t,size_t>  key;
+        key = std::make_pair(i,i);
+
+        std::pair<std::pair<size_t,size_t>, FP_TYPE> map_pair;
+        map_pair= std::make_pair(key,val);
+        value_Map.insert(map_pair);
+        val = val + 1; 
+        
+    }
+    
+    //set coefficients of sparse matrix to be the values in the map
+    mat->setCoefficients(value_Map);
+    mat->matVec(x,b);
+    //loop over values of b and check they are the same as b_sol
+    for (size_t i = 0;i < cols; i++){
+        ASSERT_ALMOST_EQUAL(b_sol[i],b[i],1e-6);
+    }
+    delete mat;
+}   
+//Test for zero matrix matvec
+TEST(MatVec_CRS_Zero){
+    //num rows and cols for matrix
+    size_t rows = 10;
+    size_t cols = 10;
+    SparseMatrix<FP_TYPE> * mat = Matrix_Factory("CRS",rows,cols);
+    FP_TYPE x[10] = {1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0,9.0,10.0};
+    FP_TYPE b[10];
+    mat->matvec(x,b);
+    //loop over values of b and check they are the same as x x was multiplied by the identity matrix
+    for (size_t i = 0;i < cols; i++){
+        ASSERT_ALMOST_EQUAL(0,b[i],1e-6);
+    }
+    delete mat;
+}
+//Tests for banded matvec
+TEST(MatVec_CRS_BANDED){
+    //num rows and cols for matrix
+    size_t rows = 10;
+    size_t cols = 10;
+    SparseMatrix<FP_TYPE> * mat = Matrix_Factory("CRS",rows,cols);
+    FP_TYPE x[10] = {1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0};
+    FP_TYPE b[10];
+    FP_TYPE b_sol[10] = {1.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0};
+    std::map<std::pair<size_t,size_t>, FP_TYPE > value_Map;
+    for(size_t i = 0; i < rows; i++){
+        std::pair<size_t,size_t>  key;
+        key = std::make_pair(i,i);
+        std::pair<std::pair<size_t,size_t>, FP_TYPE> map_pair;
+        map_pair= std::make_pair(key,2);
+        value_Map.insert(map_pair);
+
+        if (i > 0){
+            std::pair<size_t,size_t>  key;
+            key = std::make_pair(i,i-1);
+            std::pair<std::pair<size_t,size_t>, FP_TYPE> map_pair;
+            map_pair= std::make_pair(key,-1);
+            value_Map.insert(map_pair);
+        }
+        
+        if (i < rows-1){
+            std::pair<size_t,size_t>  key;
+            key = std::make_pair(i,i+1);
+            std::pair<std::pair<size_t,size_t>, FP_TYPE> map_pair;
+            map_pair= std::make_pair(key,-1);
+            value_Map.insert(map_pair);
+        }
+    }
+    
+    //set coefficients of sparse matrix to be the values in the map
+    mat->setCoefficients(value_Map);
+    mat->matVec(x,b);
+    //loop over values of b and check they are the same as b_sol
+    for (size_t i = 0;i < cols; i++){
+        ASSERT_ALMOST_EQUAL(b_sol[i],b[i],1e-6);
+    }
+    delete mat;
+}
+//test for random dense matvec
+TEST(MatVec_CRS_Dense){
+    size_t rows = 10;
+    size_t cols = 10;
+    SparseMatrix<FP_TYPE> * mat = Matrix_Factory("CRS",rows,cols);
+    FP_TYPE mat_dense[10][10];
+    FP_TYPE x[10] = {1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0,9.0,10.0};
+    FP_TYPE b[10];
+    FP_TYPE b_sol[10] = {0,0,0,0,0,0,0,0,0,0};
+    std::map<std::pair<size_t,size_t>, FP_TYPE > value_Map;
+    //set random seed so test dont change run to run
+    srand(100);
+    for(size_t i = 0; i < rows; i++){
+        for (size_t j = 0; j<cols; j++){
+            FP_TYPE val = rand();
+            mat_dense[i][j] = val;
+            std::pair<size_t,size_t>  key;
+            key = std::make_pair(i,i);
+            std::pair<std::pair<size_t,size_t>, FP_TYPE> map_pair;
+            map_pair = std::make_pair(key,val);
+            value_Map.insert(map_pair);
+        }
+
+    }
+
+    // dense matrix vector multiplication (known implemenation)
+    for (size_t i  = 0; i <rows; i++){
+        for (size_t j = 0; j<cols; j++){
+            b_sol[i] = b_sol[i] + mat_dense[i][j]*x[j];
+        }
+    }
+    
+    //set coefficients of sparse matrix to be the values in the map
+    mat->setCoefficients(value_Map);
+    mat->matvec(x,b);
+    //loop over values of b and check they are the same as x x was multiplied by the identity matrix
+    for (size_t i = 0;i < cols; i++){
+        ASSERT_ALMOST_EQUAL(b_sol[i],b[i],1e-6);
+    }
+
+    delete mat;
+}
+
+TEST MAIN()

--- a/test/testSparseMatVec_ELLPACK.cpp
+++ b/test/testSparseMatVec_ELLPACK.cpp
@@ -1,0 +1,176 @@
+//TESTS FOR ELLPACK format sparse matrix runs 5 tests:
+//1) MatVec with identity matrix
+//2) MatVec with diagonal matrix
+//3) MatVec with zeros Matrix
+//4) Matvec with tridiagonal matrix
+//5) Matvec with random full desnse matrix
+#include "SparseMatrix.hpp" //import sparse matrix library
+#include "unit_test_framework.h" //for using testing framework
+#include "stdlib.h"//for random
+
+
+//Test for identity matvec multiplications
+TEST(MatVec_ELLPACK_Identity){
+    //num rows and cols for matrix
+    size_t rows = 10;
+    size_t cols = 10;
+    SparseMatrix<FP_TYPE> * mat = Matrix_Factory("ELLPACK",rows,cols);
+    FP_TYPE x[10] = {1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0,9.0,10.0};
+    FP_TYPE b[10];
+    std::map<std::pair<size_t,size_t>, FP_TYPE > value_Map;
+    for(size_t i = 0; i < rows; i++){
+
+        std::pair<size_t,size_t>  key;
+        key = std::make_pair(i,i);
+
+        std::pair<std::pair<size_t,size_t>, FP_TYPE> map_pair;
+        map_pair = std::make_pair(key,1.0);
+        value_Map.insert(map_pair);
+    }
+    
+    //set coefficients of sparse matrix to be the values in the map
+    mat->setCoefficients(value_Map);
+    mat->matvec(x,b);
+    //loop over values of b and check they are the same as x x was multiplied by the identity matrix
+    for (size_t i = 0;i < cols; i++){
+        ASSERT_ALMOST_EQUAL(x[i],b[i],1e-6);
+    }
+    delete mat;
+
+}   
+
+//Test For Diagonal matvec multiplication
+TEST(MatVec_ELLPACK_Diag){
+    //num rows and cols for matrix
+    size_t rows = 10;
+    size_t cols = 10;
+    SparseMatrix<FP_TYPE> * mat = Matrix_Factory("ELLPACK",rows,cols);
+    FP_TYPE x[10] = {1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0};
+    FP_TYPE b[10];
+    FP_TYPE b_sol[10] = {1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0,9.0,10.0};
+    std::map<std::pair<size_t,size_t>, FP_TYPE > value_Map;
+    FP_TYPE val  = 1.0;
+    for(size_t i = 0; i < rows; i++){
+        std::pair<size_t,size_t>  key;
+        key = std::make_pair(i,i);
+
+        std::pair<std::pair<size_t,size_t>, FP_TYPE> map_pair;
+        map_pair= std::make_pair(key,val);
+        value_Map.insert(map_pair);
+        val = val + 1; 
+        
+    }
+    
+    //set coefficients of sparse matrix to be the values in the map
+    mat->setCoefficients(value_Map);
+    mat->matVec(x,b);
+    //loop over values of b and check they are the same as b_sol
+    for (size_t i = 0;i < cols; i++){
+        ASSERT_ALMOST_EQUAL(b_sol[i],b[i],1e-6);
+    }
+    delete mat;
+}   
+
+//Test for zero matrix matvec
+TEST(MatVec_ELLPACK_Zero){
+    //num rows and cols for matrix
+    size_t rows = 10;
+    size_t cols = 10;
+    SparseMatrix<FP_TYPE> * mat = Matrix_Factory("ELLPACK",rows,cols);
+    FP_TYPE x[10] = {1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0,9.0,10.0};
+    FP_TYPE b[10];
+    mat->matvec(x,b);
+    //loop over values of b and check they are the same as x x was multiplied by the identity matrix
+    for (size_t i = 0;i < cols; i++){
+        ASSERT_ALMOST_EQUAL(0,b[i],1e-6);
+    }
+    delete mat;
+}
+
+//Tests for banded matvec
+TEST(MatVec_ELLPACK_BANDED){
+    //num rows and cols for matrix
+    size_t rows = 10;
+    size_t cols = 10;
+    SparseMatrix<FP_TYPE> * mat = Matrix_Factory("ELLPACK",rows,cols);
+    FP_TYPE x[10] = {1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0};
+    FP_TYPE b[10];
+    FP_TYPE b_sol[10] = {1.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0};
+    std::map<std::pair<size_t,size_t>, FP_TYPE > value_Map;
+    for(size_t i = 0; i < rows; i++){
+        std::pair<size_t,size_t>  key;
+        key = std::make_pair(i,i);
+        std::pair<std::pair<size_t,size_t>, FP_TYPE> map_pair;
+        map_pair= std::make_pair(key,2);
+        value_Map.insert(map_pair);
+
+        if (i > 0){
+            std::pair<size_t,size_t>  key;
+            key = std::make_pair(i,i-1);
+            std::pair<std::pair<size_t,size_t>, FP_TYPE> map_pair;
+            map_pair= std::make_pair(key,-1);
+            value_Map.insert(map_pair);
+        }
+        
+        if (i < rows-1){
+            std::pair<size_t,size_t>  key;
+            key = std::make_pair(i,i+1);
+            std::pair<std::pair<size_t,size_t>, FP_TYPE> map_pair;
+            map_pair= std::make_pair(key,-1);
+            value_Map.insert(map_pair);
+        }
+    }
+    
+    //set coefficients of sparse matrix to be the values in the map
+    mat->setCoefficients(value_Map);
+    mat->matVec(x,b);
+    //loop over values of b and check they are the same as b_sol
+    for (size_t i = 0;i < cols; i++){
+        ASSERT_ALMOST_EQUAL(b_sol[i],b[i],1e-6);
+    }
+    delete mat;
+}
+//test for random dense matvec
+TEST(MatVec_ELLPACK_Dense){
+    size_t rows = 10;
+    size_t cols = 10;
+    SparseMatrix<FP_TYPE> * mat = Matrix_Factory("ELLPACK",rows,cols);
+    FP_TYPE mat_dense[10][10];
+    FP_TYPE x[10] = {1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0,9.0,10.0};
+    FP_TYPE b[10];
+    FP_TYPE b_sol[10] = {0,0,0,0,0,0,0,0,0,0};
+    std::map<std::pair<size_t,size_t>, FP_TYPE > value_Map;
+    //set random seed so test dont change run to run
+    srand(100);
+    for(size_t i = 0; i < rows; i++){
+        for (size_t j = 0; j<cols; j++){
+            FP_TYPE val = rand();
+            mat_dense[i][j] = val;
+            std::pair<size_t,size_t>  key;
+            key = std::make_pair(i,i);
+            std::pair<std::pair<size_t,size_t>, FP_TYPE> map_pair;
+            map_pair = std::make_pair(key,val);
+            value_Map.insert(map_pair);
+        }
+
+    }
+
+    // dense matrix vector multiplication (known implemenation)
+    for (size_t i  = 0; i <rows; i++){
+        for (size_t j = 0; j<cols; j++){
+            b_sol[i] = b_sol[i] + mat_dense[i][j]*x[j];
+        }
+    }
+    
+    //set coefficients of sparse matrix to be the values in the map
+    mat->setCoefficients(value_Map);
+    mat->matvec(x,b);
+    //loop over values of b and check they are the same as x x was multiplied by the identity matrix
+    for (size_t i = 0;i < cols; i++){
+        ASSERT_ALMOST_EQUAL(b_sol[i],b[i],1e-6);
+    }
+
+    delete mat;
+}
+
+TEST MAIN()

--- a/test/testSparseMatrix_JDS.cpp
+++ b/test/testSparseMatrix_JDS.cpp
@@ -1,0 +1,173 @@
+//TESTS FOR JDS format sparse matrix runs 5 tests:
+//1) MatVec with identity matrix
+//2) MatVec with diagonal matrix
+//3) MatVec with zeros Matrix
+//4) Matvec with tridiagonal matrix
+//5) Matvec with random full desnse matrix
+#include "SparseMatrix.hpp" //import sparse matrix library
+#include "unit_test_framework.h" //for using testing framework
+#include "stdlib.h"//for random
+
+//Test for identity matvec
+TEST(MatVec_JDS_Identity){
+    //num rows and cols for matrix
+    size_t rows = 10;
+    size_t cols = 10;
+    SparseMatrix<FP_TYPE> * mat = Matrix_Factory("JDS",rows,cols);
+    FP_TYPE x[10] = {1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0,9.0,10.0};
+    FP_TYPE b[10];
+    std::map<std::pair<size_t,size_t>, FP_TYPE > value_Map;
+    for(size_t i = 0; i < rows; i++){
+
+        std::pair<size_t,size_t>  key;
+        key = std::make_pair(i,i);
+
+        std::pair<std::pair<size_t,size_t>, FP_TYPE> map_pair;
+        map_pair = std::make_pair(key,1.0);
+        value_Map.insert(map_pair);
+    }
+    
+    //set coefficients of sparse matrix to be the values in the map
+    mat->setCoefficients(value_Map);
+    mat->matvec(x,b);
+    //loop over values of b and check they are the same as x x was multiplied by the identity matrix
+    for (size_t i = 0;i < cols; i++){
+        ASSERT_ALMOST_EQUAL(x[i],b[i],1e-6);
+    }
+    delete mat;
+
+}   
+
+//Test For Diagonal matvec 
+TEST(MatVec_JDS_Diag){
+    //num rows and cols for matrix
+    size_t rows = 10;
+    size_t cols = 10;
+    SparseMatrix<FP_TYPE> * mat = Matrix_Factory("JDS",rows,cols);
+    FP_TYPE x[10] = {1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0};
+    FP_TYPE b[10];
+    FP_TYPE b_sol[10] = {1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0,9.0,10.0};
+    std::map<std::pair<size_t,size_t>, FP_TYPE > value_Map;
+    FP_TYPE val  = 1.0;
+    for(size_t i = 0; i < rows; i++){
+        std::pair<size_t,size_t>  key;
+        key = std::make_pair(i,i);
+
+        std::pair<std::pair<size_t,size_t>, FP_TYPE> map_pair;
+        map_pair= std::make_pair(key,val);
+        value_Map.insert(map_pair);
+        val = val + 1; 
+        
+    }
+    
+    //set coefficients of sparse matrix to be the values in the map
+    mat->setCoefficients(value_Map);
+    mat->matVec(x,b);
+    //loop over values of b and check they are the same as b_sol
+    for (size_t i = 0;i < cols; i++){
+        ASSERT_ALMOST_EQUAL(b_sol[i],b[i],1e-6);
+    }
+    delete mat;
+}   
+//Test for zero matrix matvec
+TEST(MatVec_JDS_Zero){
+    //num rows and cols for matrix
+    size_t rows = 10;
+    size_t cols = 10;
+    SparseMatrix<FP_TYPE> * mat = Matrix_Factory("JDS",rows,cols);
+    FP_TYPE x[10] = {1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0,9.0,10.0};
+    FP_TYPE b[10];
+    mat->matvec(x,b);
+    //loop over values of b and check they are the same as x x was multiplied by the identity matrix
+    for (size_t i = 0;i < cols; i++){
+        ASSERT_ALMOST_EQUAL(0,b[i],1e-6);
+    }
+    delete mat;
+}
+//Tests for banded matvec
+TEST(MatVec_JDS_BANDED){
+    //num rows and cols for matrix
+    size_t rows = 10;
+    size_t cols = 10;
+    SparseMatrix<FP_TYPE> * mat = Matrix_Factory("JDS",rows,cols);
+    FP_TYPE x[10] = {1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0};
+    FP_TYPE b[10];
+    FP_TYPE b_sol[10] = {1.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0};
+    std::map<std::pair<size_t,size_t>, FP_TYPE > value_Map;
+    for(size_t i = 0; i < rows; i++){
+        std::pair<size_t,size_t>  key;
+        key = std::make_pair(i,i);
+        std::pair<std::pair<size_t,size_t>, FP_TYPE> map_pair;
+        map_pair= std::make_pair(key,2);
+        value_Map.insert(map_pair);
+
+        if (i > 0){
+            std::pair<size_t,size_t>  key;
+            key = std::make_pair(i,i-1);
+            std::pair<std::pair<size_t,size_t>, FP_TYPE> map_pair;
+            map_pair= std::make_pair(key,-1);
+            value_Map.insert(map_pair);
+        }
+        
+        if (i < rows-1){
+            std::pair<size_t,size_t>  key;
+            key = std::make_pair(i,i+1);
+            std::pair<std::pair<size_t,size_t>, FP_TYPE> map_pair;
+            map_pair= std::make_pair(key,-1);
+            value_Map.insert(map_pair);
+        }
+    }
+    
+    //set coefficients of sparse matrix to be the values in the map
+    mat->setCoefficients(value_Map);
+    mat->matVec(x,b);
+    //loop over values of b and check they are the same as b_sol
+    for (size_t i = 0;i < cols; i++){
+        ASSERT_ALMOST_EQUAL(b_sol[i],b[i],1e-6);
+    }
+    delete mat;
+}
+//test for random dense matvec
+TEST(MatVec_JDS_Dense){
+    size_t rows = 10;
+    size_t cols = 10;
+    SparseMatrix<FP_TYPE> * mat = Matrix_Factory("JDS",rows,cols);
+    FP_TYPE mat_dense[10][10];
+    FP_TYPE x[10] = {1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0,9.0,10.0};
+    FP_TYPE b[10];
+    FP_TYPE b_sol[10] = {0,0,0,0,0,0,0,0,0,0};
+    std::map<std::pair<size_t,size_t>, FP_TYPE > value_Map;
+    //set random seed so test dont change run to run
+    srand(100);
+    for(size_t i = 0; i < rows; i++){
+        for (size_t j = 0; j<cols; j++){
+            FP_TYPE val = rand();
+            mat_dense[i][j] = val;
+            std::pair<size_t,size_t>  key;
+            key = std::make_pair(i,i);
+            std::pair<std::pair<size_t,size_t>, FP_TYPE> map_pair;
+            map_pair = std::make_pair(key,val);
+            value_Map.insert(map_pair);
+        }
+
+    }
+
+    // dense matrix vector multiplication (known implemenation)
+    for (size_t i  = 0; i <rows; i++){
+        for (size_t j = 0; j<cols; j++){
+            b_sol[i] = b_sol[i] + mat_dense[i][j]*x[j];
+        }
+    }
+    
+    //set coefficients of sparse matrix to be the values in the map
+    mat->setCoefficients(value_Map);
+    mat->matvec(x,b);
+    //loop over values of b and check they are the same as x x was multiplied by the identity matrix
+    for (size_t i = 0;i < cols; i++){
+        ASSERT_ALMOST_EQUAL(b_sol[i],b[i],1e-6);
+    }
+
+    delete mat;
+}
+
+TEST MAIN()


### PR DESCRIPTION
Addresses Issue #6 and #5. 

This PR includes tests for Sparse-Matrix vector multiplication for COO, CRS, BCRS, JDS, and ELLPACK matrix types. Included in each file is a tests that tests the matrix-vector multiplication of the identity matrix, a diagonal matrix, a zeros matrix, a banded matrix, and a full dense matrix.

Because these tests were written before any implementation has been complete an assumed way of creating the matrices and building them were used. Following the #55 some updates were made to followthe outline for functions there but implementation of a sparse matrix factory still needs to be complete. If the structure of the code changes updates to the tests will be needed

This PR does not include any updates to the cmake system as the matrix formats have not been fully implemented and relies on functions that do not exist. This was done to avoid having any issues with code no compiling/all tests failing not allowing for tests to be merged.